### PR TITLE
Update yq commands to use 4.x UI

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -59,7 +59,7 @@ runs:
       run: |
         if [[ -n "${{ inputs.runtime-path }}" ]]; then
           echo "::warning::The runtime-path input is deprecated. Please use runtime-paths instead."
-          RUNTIME_PATHS="${{ inputs.runtime-path }}"
+          RUNTIME_PATHS="- ${{ inputs.runtime-path }}"
         else
           RUNTIME_PATHS="${{ inputs.runtime-paths }}"
         fi
@@ -73,7 +73,7 @@ runs:
             echo "::error file=$runtimePath::While running $runtimePath"
           fi
           echo "::endgroup::"
-        done <<<"$(echo "$RUNTIME_PATHS" | yq read - [*])"
+        done <<<"$(echo "$RUNTIME_PATHS" | yq eval '.[]' -)"
         exit $EXIT_STATUS
 
     - name: Parse coverage-exclude-paths input
@@ -82,7 +82,7 @@ runs:
       run: |
         while IFS='' read -r excludePath && [[ -n "$excludePath" ]]; do
           excludePaths="$excludePaths $excludePath"
-        done <<<"$(echo "${{ inputs.coverage-exclude-paths }}" | yq read - [*])"
+        done <<<"$(echo "${{ inputs.coverage-exclude-paths }}" | yq eval '.[]' -)"
         # Make the parsed paths an output so it can be used by the next step
         echo "::set-output name=paths::$excludePaths"
 

--- a/action.yml
+++ b/action.yml
@@ -44,6 +44,11 @@ runs:
       run: |
         sudo snap install yq > /dev/null
 
+    - name: Update APT package lists
+      shell: bash
+      run: |
+        sudo apt-get update > /dev/null
+
     - name: Install Valgrind
       shell: bash
       run: |


### PR DESCRIPTION
The recent yq 4.0.0 release [completely reworked the UI](https://mikefarah.gitbook.io/yq/v/v4.x/upgrading-from-v3), breaking compatibility with all previous commands, and thus the action:
```
Error: unknown command "read" for "yq"
```
---
Example of failing workflow run caused by this issue:
https://github.com/107-systems/107-Arduino-UAVCAN/runs/1628914972?check_suite_focus=true
Equivalent workflow run using the fixed version of the action from this PR:
https://github.com/per1234/107-Arduino-UAVCAN/runs/1629305291?check_suite_focus=true