### PR TITLE
Use v1 ref in example snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: arduino/cpp-test-action@main
+      - uses: arduino/cpp-test-action@v1
         with:
           coverage-data-path: ${{ env.COVERAGE_DATA_PATH }}
 


### PR DESCRIPTION
The v1 branch will be updated on every release that increments the minor or patch version. Therefore, the use of this ref in workflows will result in the workflow automatically benefiting from ongoing improvements or fixes that don't cause a breaking change.