### PR TITLE
Don't limit number of open Dependabot pull requests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,7 @@ updates:
     directory: / # Check the repository's workflows under /.github/workflows/
     assignees:
       - per1234
+    open-pull-requests-limit: 100
     schedule:
       interval: daily
     labels:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
   # See: https://docs.github.com/en/code-security/supply-chain-security/keeping-your-actions-up-to-date-with-dependabot
   - package-ecosystem: github-actions
     directory: / # Check the repository's workflows under /.github/workflows/
+    assignees:
+      - per1234
     schedule:
       interval: daily
     labels:


### PR DESCRIPTION
The [**Dependabot**](https://docs.github.com/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates) service is used to keep the project dependencies updated.

Thanks to the project's high quality validation infrastructure, the human effort required to complete a trivial version bump is minimal. However, some bumps may introduce breaking changes that would require a significant amount of effort to accommodate, or are blocked by external tasks. In this case, the **Dependabot** pull request can't be merged, but should be left open to track the need to perform the bump when it is feasible. This means that it should be expected that there will be regularly be a small number of **Dependabot** pull requests left open in the repository over long periods of time. The automated system is here to assist the human project maintainers, not as a tyrannical overlord, so this is the system working exactly as intended.

By default, **Dependabot** is [configured to stop submitting pull requests](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#open-pull-requests-limit) if it already has five open pull requests. This means that if it happens that the accumulation of intentionally on hold pull requests reaches that number, the project stops receiving the easily handled trivial update PRs. This is very harmful because it results in the completely unnecessary use of outdated dependencies, and unnecessary challenging large bumps when pull requests start being submitted once more after the backlog is cleared.

The harmful default configuration is hereby overridden by configuring the maximum open pull request limit at 100. This value was chosen as an arbitrary large number simply to functionally disable the limiting, rather than from any expectation that the actual number of open PRs can ever reach that count.